### PR TITLE
Align figure images to center

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -123,11 +123,14 @@ figure {
   box-sizing: border-box;
   display: inline-block;
   max-width: 100%;
+  width: 100%;
+  text-align: center;
 }
 
 figure img {
   max-height: 500px;
   max-width: 100%;
+  margin: 0 auto 0 auto;
 }
 
 figure h4 {


### PR DESCRIPTION
This PR aligns figure images to the center instead of keeping them aligned to the left.