### PR TITLE
Make figures caption minimal

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -135,7 +135,7 @@ figure img {
 
 figure h4 {
   margin-bottom: 1em;
-  padding-left: 2rem !important;
+  /* padding-left: 2rem !important; */
   font-size: 0.85rem !important;
   font-weight: lighter !important;
   position: relative;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -142,9 +142,7 @@ figure h4 {
 }
 
 figure h4::before {
-  content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='%23777777'><path d='M9.983 3v7.391C9.983 16.095 6.252 19.961 1 21l-.995-2.151C2.437 17.932 4 15.211 4 13H0V3h9.983zM24 3v7.391c0 5.704-3.748 9.571-9 10.609l-.996-2.151C16.437 17.932 18 15.211 18 13h-3.983V3H24z'/></svg>") !important;
-  position: absolute;
-  left: 0
+  content: '' !important;
 }
 
 /* Cool blockquote style from catalinred */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -136,7 +136,7 @@ figure img {
 figure h4 {
   margin-bottom: 1em;
   padding-left: 2rem !important;
-  font-size: 1rem !important;
+  font-size: 0.85rem !important;
   font-weight: lighter !important;
   position: relative;
   overflow: hidden;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -137,8 +137,10 @@ figure h4 {
   margin-bottom: 1em;
   padding-left: 2rem !important;
   font-size: 1rem !important;
+  font-weight: lighter !important;
   position: relative;
   overflow: hidden;
+  opacity: 0.9;
 }
 
 figure h4::before {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -135,7 +135,6 @@ figure img {
 
 figure h4 {
   margin-bottom: 1em;
-  /* padding-left: 2rem !important; */
   font-size: 0.85rem !important;
   font-weight: lighter !important;
   position: relative;


### PR DESCRIPTION
With this PR, the figures caption are more minimal:

- SVG before the caption text has been removed
- Font size reduced from `1rem` to `0.85rem`
- Caption left padding has been removed
- Caption opacity reduced to `0.9`
- Font weight changed to `lighter`