### PR TITLE
Change mark background color to primary-variant

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,6 +58,10 @@ code:not(.highlight *) {
   padding: 1em;
 }
 
+mark {
+  background-color: var(--primary-variant) !important;
+}
+
 kbd {
   background-color: var(--bg-variant) !important;
   font-family: 'Red Hat Mono', monospace !important;


### PR DESCRIPTION
This PR change the `<mark>` tag background color to the `--primary-variant` variable, to make it possible to fit to all color palettes.