### PR TITLE
Fix the Gist shortcode style

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -42,29 +42,30 @@ a:hover {
   }
 }
 
-table {
+table:not(.gist-data *) {
   border-collapse: collapse;
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
 @media (min-width: 1200px) {
-  table {
+  table:not(.gist-data *) {
     width: 100%;
   }
 }
 
-th, td {
+th:not(.gist-data *),
+td:not(.gist-data *) {
   padding: .5rem;
   text-align: left;
 }
 
-th {
+th:not(.gist-data *) {
   font-weight: bold;
   background-color: var(--bg-variant);
 }
 
-td {
+td:not(.gist-data *) {
   border-bottom: 2px solid var(--bg-variant) !important;
 }
 


### PR DESCRIPTION
The new table styles were applied also to the Gist shortcode, risulting in an ugly white box with border under each code row. This PR fixes this, removing the table style from the Gist shortcode.