### PR TITLE
Disable easy selection on multilines code

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -78,13 +78,13 @@ ul > li:has(input[type=checkbox]) {
 }
 
 code {
-  user-select: all;
   font-family: 'Red Hat Mono', serif !important;
 }
 
 code:not(.highlight *) {
   color: var(--secondary);
   font-weight: 600;
+  user-select: all;
 }
 
 .highlight > div {


### PR DESCRIPTION
This PR removes the easy selection from multilines code, using this way the user can easily select only what he needs and not the entire block of lines.