### PR TITLE
Add theme option to enable posts summary in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ You can enable the math rendering by adding `math: true` in the page metadata.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+#### Posts Summary in the Posts list
+
+You can enable the posts summary rendering in the Posts list by configuring the `showPostsSummary` parameter:
+
+```toml
+showPostsSummary = true
+```
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 ## Built With
 
 * [Hugo](https://gohugo.io/) - The static site generator framework

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,7 @@ copyright = "Sample custom notice © {year}"
 theme = "dark"
 palette = "catpuccin"
 showThemeNotice = true
+showPostsSummary = true
 
 # Navigation
 [menu]

--- a/exampleSite/content/posts/example-post.md
+++ b/exampleSite/content/posts/example-post.md
@@ -6,6 +6,7 @@ description: "This is an example post for not-much theme."
 keywords: ["gohugo", "hugo", "go", "blog"]
 draft: false
 tags: ["hugo"]
+summary: This is an example post with a very short content and a single header.
 ---
 
 ## The standard Lorem Ipsum passage

--- a/exampleSite/content/posts/hugo-shortcodes.md
+++ b/exampleSite/content/posts/hugo-shortcodes.md
@@ -4,6 +4,7 @@ description: Here is a demo of all shortcodes available in Hugo.
 date: 2024-12-27
 keywords: ["gohugo", "hugo", "go", "blog"]
 tags: ["hugo", "themes"]
+summary: This post shows the default Hugo shortcodes and how they are rendered.
 ---
 
 ## Details

--- a/exampleSite/content/posts/markdown-syntax.md
+++ b/exampleSite/content/posts/markdown-syntax.md
@@ -7,11 +7,10 @@ keywords: ["gohugo", "hugo", "go", "blog"]
 draft: false
 tags: ["markdown", "css", "html", "themes"]
 math: true
+summary: This article offers a sample of basic Markdown syntax that can be used in Hugo content files, also it shows whether basic HTML elements are decorated with CSS in a Hugo theme.
 ---
 
 This article offers a sample of basic Markdown syntax that can be used in Hugo content files, also it shows whether basic HTML elements are decorated with CSS in a Hugo theme.
-
-<!--more-->
 
 ## Headings
 

--- a/exampleSite/content/posts/math-typesetting.md
+++ b/exampleSite/content/posts/math-typesetting.md
@@ -4,10 +4,10 @@ title: Math Typesetting
 date: 2024-12-27
 description: A brief guide to setup KaTeX
 math: true
+summary: This is an example post with math notations.
 ---
 
 Mathematical notation in a Hugo project can be enabled by using third party JavaScript libraries.
-<!--more-->
 
 In this example we will be using [KaTeX](https://katex.org/)
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,11 @@
       {{ $dateHuman := .Date | time.Format ":date_long" }}
       <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
       <h2 class="h5"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-      <!-- {{ .Summary }} -->
+      {{ if .Site.Params.showPostsSummary }}
+      <p>
+        {{ .Summary }}
+      </p>
+      {{ end }}
     </div>
     {{ end }}
     {{ $paginator := .Paginator }}


### PR DESCRIPTION
This PR adds a new theme option (`showPostsSummary`) that can be used to enable (or disable) the posts summary in the posts list.