### PR TITLE
Set the img max-width

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -164,6 +164,10 @@ kbd {
 	text-decoration: none !important;
 }
 
+img {
+  max-width: 100%;
+}
+
 figure {
   box-sizing: border-box;
   display: inline-block;


### PR DESCRIPTION
This PR fixes the image size issue that causes the image to overflow the container. This fix sets the image `max-width` to 100% and keeps the image within the container.