### PR TITLE
Add the table of contents on medium/large devices

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -243,3 +243,34 @@ ul:has(input[type=checkbox]) {
 li > input[type=checkbox] {
   margin-right: 0.2rem;
 }
+
+.toc-title {
+  font-size: smaller;
+}
+
+.toc {
+  font-family: 'Red Hat Mono', serif !important;
+  margin-right: 0.7rem;
+  opacity: 0.3;
+  /* Opacity Transition */
+  -webkit-transition: opacity 1s ease-in-out;
+  -moz-transition: opacity 1s ease-in-out;
+  -ms-transition: opacity 1s ease-in-out;
+  -o-transition: opacity 1s ease-in-out;
+  transition: opacity 1s ease-in-out;
+  /* Margin Transition */
+  -webkit-transition: margin 1s ease-in-out;
+  -moz-transition: margin 1s ease-in-out;
+  -ms-transition: margin 1s ease-in-out;
+  -o-transition: margin 1s ease-in-out;
+  transition: margin 1s ease-in-out;
+
+  &:hover {
+    margin-right: 1.5rem;
+    opacity: 1;
+  }
+}
+
+#TableOfContents > ul {
+  list-style-type: '//  ';
+}

--- a/exampleSite/content/posts/hugo-shortcodes.md
+++ b/exampleSite/content/posts/hugo-shortcodes.md
@@ -5,6 +5,7 @@ date: 2024-12-27
 keywords: ["gohugo", "hugo", "go", "blog"]
 tags: ["hugo", "themes"]
 summary: This post shows the default Hugo shortcodes and how they are rendered.
+toc: true
 ---
 
 ## Details

--- a/exampleSite/content/posts/toc-showcase.md
+++ b/exampleSite/content/posts/toc-showcase.md
@@ -1,0 +1,27 @@
+---
+title: "Hugo Table of Contents showcase"
+description: Here is a demo of the Table of Contents.
+date: 2025-03-13
+keywords: ["gohugo", "hugo", "go", "blog"]
+tags: ["hugo", "themes"]
+summary: This post shows the default Hugo Table of Contents and how not-much handle it.
+toc: true
+---
+
+## How not-much handle the ToC
+
+By default, Hugo supports the Table of Contents generation by setting the `toc` parameter to `true` or `false` in the page metadata. `not-much` theme is rendering the Table of Contents only on devices with a screen dimension ≥ 768px.
+
+If you are on medium/large device, you will find the ToC on the right side of the screen.
+
+### Nested Chapter
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam facilisis leo quis condimentum rutrum. Etiam sed neque risus. Etiam congue nec ligula non dignissim. Praesent ut nibh at ipsum tincidunt volutpat ac sed velit. Fusce sit amet nisi erat. Etiam et congue nisi. Proin ac euismod libero. Pellentesque in pharetra diam. Morbi at mi felis. Proin sodales enim in felis pharetra, ornare commodo sem vestibulum. In cursus nisi eget hendrerit convallis. Praesent ipsum diam, consequat et efficitur sit amet, lobortis vel arcu. In non pharetra mauris, vel semper sapien. Duis non venenatis urna. Suspendisse eu eros lacinia, convallis augue quis, finibus purus.
+
+## Chapter with emoji ⌨️
+
+Quisque in posuere metus. Vivamus sapien ex, consequat nec libero eget, feugiat euismod arcu. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tincidunt velit vel rutrum vehicula. Vivamus quis ultricies lectus. Quisque porta auctor pellentesque. Morbi in hendrerit nisi, in viverra nisl. Praesent cursus aliquet sodales. Sed ut ante ac est semper faucibus nec quis erat. Integer mollis nisi in tristique ultricies. Vivamus ut turpis sed sem finibus rutrum sit amet non dui. Duis eu enim ipsum. Phasellus tincidunt metus euismod quam venenatis molestie. Aliquam consequat velit sed erat venenatis mollis. Donec imperdiet mattis est ut blandit. Nulla felis ante, tincidunt quis commodo ut, posuere ac arcu.
+
+### Third-level
+
+Donec consequat malesuada molestie. Nam neque augue, hendrerit id velit non, lacinia malesuada erat. Quisque tincidunt, ligula id imperdiet malesuada, tellus tellus suscipit ligula, ac sagittis leo tortor eu est. Cras sodales libero libero, at elementum dui molestie nec. Pellentesque luctus id turpis vitae lobortis. Maecenas efficitur venenatis nibh. Fusce at molestie orci. Interdum et malesuada fames ac ante ipsum primis in faucibus.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,6 +3,14 @@
     <div class="row mt-5 pt-5">
       {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
     </div>
+    {{ if .Params.toc }}
+    <div class="d-none d-md-block position-fixed end-0 small toc">
+      <p class="toc-title">
+        Table of Contents:
+      </p>
+      {{ .TableOfContents }}
+    </div>
+    {{ end }}
     <div class="post">
       <header class="mb-4">
         <h1 class="text-uppercase">{{ .Title }}</h1>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
       {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
     </div>
     {{ if .Params.toc }}
-    <div class="d-none d-md-block position-fixed end-0 small toc">
+    <div class="d-none d-lg-block position-fixed small toc">
       <p class="toc-title">
         Table of Contents:
       </p>


### PR DESCRIPTION
This PR adds the Table of Contents on medium/large devices for pages that are enabling it with the `toc` parameter in the metadata.