### PR TITLE
Change badge class font family and weight

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -279,3 +279,8 @@ li > input[type=checkbox] {
 #TableOfContents > ul {
   list-style-type: '//  ';
 }
+
+.badge {
+  font-family: 'Red Hat Mono', serif !important;
+  font-weight: 600 !important;
+}


### PR DESCRIPTION
This PR changes the `.badge` class font styles:

- Font family set to `Red Hat Mono`
- Font weight set to `600`