### PR TITLE
Align term page with the latest changes

### DIFF
--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -11,6 +11,11 @@
         {{ $dateHuman := .Date | time.Format ":date_long" }}
         <time class="small" datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
         <h2 class="h5"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
+        {{ if .Site.Params.showPostsSummary }}
+        <p class="small opacity-75 post-summary">
+          {{ .Summary }}
+        </p>
+        {{ end }}
 
         {{ range .Data.Pages }}
         {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -9,15 +9,14 @@
       <div class="row mb-3">
         {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
         {{ $dateHuman := .Date | time.Format ":date_long" }}
-        <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
-        <h2 class="h4"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-        <!-- {{ .Summary }} -->
+        <time class="small" datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+        <h2 class="h5"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
 
         {{ range .Data.Pages }}
         {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
         {{ $dateHuman := .Date | time.Format ":date_long" }}
-        <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
-        <h2 class="h4"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+        <time class="small" datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+        <h2 class="h5"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
         {{ end }}
       </div>
       {{ end }}


### PR DESCRIPTION
This PR aligns the term page with the latest changes:

- Elements title class set to `h5`
- Timestamp class set to `small`
- Show the element summary if enabled