### PR TITLE
Fix the color scheme detection

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
       if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
           themeClasses = ["text-light", "dark"];
       }
-      document.body.classList.add(themeClasses);
+      document.body.classList.add(...themeClasses);
     }
 
     detectThemePreferences();


### PR DESCRIPTION
This PR fixes the color scheme detection, cause the code was adding a comma in the body class list, preventing the classes from being recognised and applied.

```diff
- <body class="text-light,dark">
+ <body class="text-light dark">
```