### PR TITLE
Add terms template

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -304,3 +304,9 @@ hr {
     currentColor 75%);
   background-size: 4px 4px;
 }
+
+.terms-char {
+  &::before {
+    content: '― ';
+  }
+}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+<div class="container pt-5">
+    <div class="row mt-5 pt-5">
+        {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
+    </div>
+
+    {{ $letters := split "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "" }}
+    <div class="d-flex flex-column align-items-start">
+    {{ range sort .Site.Taxonomies.tags }}
+        <!-- This assumes the title is never empty -->
+        {{ $firstChar := substr .Page.Title 0 1 | upper }}
+        {{ if $firstChar | in $letters }}
+            {{ $curLetter := $.Scratch.Get "curLetter" }}
+            {{ if ne $firstChar $curLetter }}
+            {{ $.Scratch.Set "curLetter" $firstChar }}
+                <span class="terms-char pt-2 pb-1">{{ $firstChar }}</span>
+            {{ end }}
+            <a class="badge text-uppercase" href="{{ .Page.Permalink }}">{{ .Page.Title }} ({{ .Count }})</a>
+        {{ end }}
+    {{ end }}
+    </div>
+{{ end }}


### PR DESCRIPTION
This PR adds the `terms.html` template used to display the list of tags used.

![image](https://github.com/user-attachments/assets/95c87235-e346-45e3-89b6-68ac9ad3d6f6)
