### PR TITLE
Add north-east arrow after post's anchors

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -147,6 +147,10 @@ kbd {
   color: var(--secondary);
 }
 
+.post article a:not(.footnote-backref)::after {
+  content: " ↗"
+}
+
 .post .draft-label {
   font-weight: bold;
   color: var(--primary);


### PR DESCRIPTION
This PR adds a north-east arrow character to the end of each post's anchors to make the link more visually appealing.

From [test anchor](#) to [test anchor ↗](#)