### PR TITLE
Tag badges dynamic text color using variables

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,7 +162,7 @@ kbd {
 
 .tags a:hover {
   background-color: var(--primary) !important;
-  color: #fff !important;
+  color: var(--selection-color) !important;
   text-decoration: none !important;
 }
 


### PR DESCRIPTION
This PR fixes a bug where the tag badges were difficult to read because the color was set to `#fff`. This has been resolved by using the `--selection-color` variable, which makes the text colour of the chips dynamic and aligned with the palette.