### PR TITLE
Enhance anchors readability

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,6 +34,8 @@ nav a:hover, a:hover {
 
 a {
   color: var(--primary-variant) !important;
+  text-decoration: underline !important;
+  text-underline-offset: 0.375em !important;
 }
 
 a:hover {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -33,7 +33,6 @@ nav a:hover, a:hover {
 }
 
 a {
-  font-weight: 600;
   color: var(--primary-variant) !important;
 }
 


### PR DESCRIPTION
The aim of this PR is to improve readability by adapting the weight of the anchors to match the theme style and adding an underline effect.

For instance, the about page changes from:

<img width="713" height="273" alt="image" src="https://github.com/user-attachments/assets/571a4fbb-c1ca-413b-b51f-eff6de1502b7" />

To:

<img width="712" height="270" alt="image" src="https://github.com/user-attachments/assets/b1ad8158-19e3-4475-a895-337e092a5e07" />
