### PR TITLE
Fix the Table of Contents position

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -292,6 +292,35 @@ li > input[type=checkbox] {
   }
 }
 
+/* Viewport ≥ 768px: container = 720px */
+@media (min-width: 768px) {
+  .toc {
+    display: block;
+    right: calc(50% - 360px - 20px); /* 720px / 2 */
+  }
+}
+
+/* Viewport ≥ 992px: container = 960px */
+@media (min-width: 992px) {
+  .toc {
+    right: calc(50% - 480px - 20px); /* 960px / 2 */
+  }
+}
+
+/* Viewport ≥ 1200px: container = 1140px */
+@media (min-width: 1200px) {
+  .toc {
+    right: calc(50% - 570px - 20px); /* 1140px / 2 */
+  }
+}
+
+/* Viewport ≥ 1400px: container = 1320px */
+@media (min-width: 1400px) {
+  .toc {
+    right: calc(50% - 660px - 20px); /* 1320px / 2 */
+  }
+}
+
 #TableOfContents > ul {
   list-style-type: '//  ';
 }

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
       {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
     </div>
     {{ if .Params.toc }}
-    <div class="d-none d-lg-block position-fixed end-0 small toc">
+    <div class="d-none d-lg-block position-fixed small toc">
       <p class="toc-title">
         Table of Contents:
       </p>


### PR DESCRIPTION
This PR fixes the position of the Table of Contents, moving it closer to the main container. Otherwise, on a big screen, it's quite uncomfortable.

From:

<img width="1579" height="402" alt="image" src="https://github.com/user-attachments/assets/5c639037-c1a8-4a45-a470-113e36e517d5" />

To:

<img width="1151" height="404" alt="image" src="https://github.com/user-attachments/assets/59fe31e8-3477-4369-bad9-b6c8281c1a8e" />
