### PR TITLE
Remove tag badges text decoration

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -167,6 +167,10 @@ kbd {
   color: #6c757d !important;
 }
 
+.tags a {
+  text-decoration: none !important;
+}
+
 .tags a:hover {
   background-color: var(--primary) !important;
   color: var(--selection-color) !important;


### PR DESCRIPTION
This PR fixes the post tag badges by removing the text decoration:

| Before | After |
|:------:|:-----:|
| <img width="242" height="118" alt="image" src="https://github.com/user-attachments/assets/2c7feec1-92bb-4450-bd7f-7e5788170919" /> | <img width="223" height="124" alt="image" src="https://github.com/user-attachments/assets/2756b7e0-c965-4561-ada9-fda2ee11a4ae" /> |
