### PR TITLE
Remove north-east arrow for anchors with image

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -158,6 +158,10 @@ kbd {
   content: " ↗"
 }
 
+.post article a:has(img)::after {
+  content: none !important;
+}
+
 .post .draft-label {
   font-weight: bold;
   color: var(--primary);


### PR DESCRIPTION
This PR removes the north-west arrow when the anchor contains image.

<img width="710" height="190" alt="image" src="https://github.com/user-attachments/assets/8b1e4b54-7dab-4d78-8065-650577df9985" />
