### PR TITLE
Show the Table of Contents on small devices

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -279,10 +279,6 @@ li > input[type=checkbox] {
 
 .toc {
   font-family: 'Red Hat Mono', serif !important;
-  opacity: 0.2;
-  &:hover {
-    opacity: 1;
-  }
 }
 
 /* Viewport ≥ 768px: container = 720px */
@@ -292,6 +288,7 @@ li > input[type=checkbox] {
     position: fixed !important;
     right: calc(50% - 360px - 20px); /* 720px / 2 */
     margin-right: 1.5rem;
+    opacity: 0.2;
     /* Opacity Transition */
     -webkit-transition: opacity 1s ease-in-out;
     -moz-transition: opacity 1s ease-in-out;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -279,23 +279,8 @@ li > input[type=checkbox] {
 
 .toc {
   font-family: 'Red Hat Mono', serif !important;
-  margin-right: 1.5rem;
   opacity: 0.2;
-  /* Opacity Transition */
-  -webkit-transition: opacity 1s ease-in-out;
-  -moz-transition: opacity 1s ease-in-out;
-  -ms-transition: opacity 1s ease-in-out;
-  -o-transition: opacity 1s ease-in-out;
-  transition: opacity 1s ease-in-out;
-  /* Margin Transition */
-  -webkit-transition: margin 1s ease-in-out;
-  -moz-transition: margin 1s ease-in-out;
-  -ms-transition: margin 1s ease-in-out;
-  -o-transition: margin 1s ease-in-out;
-  transition: margin 1s ease-in-out;
-
   &:hover {
-    margin-right: 2.3rem;
     opacity: 1;
   }
 }
@@ -303,8 +288,27 @@ li > input[type=checkbox] {
 /* Viewport ≥ 768px: container = 720px */
 @media (min-width: 768px) {
   .toc {
-    display: block;
+    display: block !important;
+    position: fixed !important;
     right: calc(50% - 360px - 20px); /* 720px / 2 */
+    margin-right: 1.5rem;
+    /* Opacity Transition */
+    -webkit-transition: opacity 1s ease-in-out;
+    -moz-transition: opacity 1s ease-in-out;
+    -ms-transition: opacity 1s ease-in-out;
+    -o-transition: opacity 1s ease-in-out;
+    transition: opacity 1s ease-in-out;
+    /* Margin Transition */
+    -webkit-transition: margin 1s ease-in-out;
+    -moz-transition: margin 1s ease-in-out;
+    -ms-transition: margin 1s ease-in-out;
+    -o-transition: margin 1s ease-in-out;
+    transition: margin 1s ease-in-out;
+
+    &:hover {
+      margin-right: 2.3rem;
+      opacity: 1;
+    }
   }
 }
 

--- a/exampleSite/content/posts/toc-showcase.md
+++ b/exampleSite/content/posts/toc-showcase.md
@@ -10,9 +10,10 @@ toc: true
 
 ## How not-much handle the ToC
 
-By default, Hugo supports the Table of Contents generation by setting the `toc` parameter to `true` or `false` in the page metadata. `not-much` theme is rendering the Table of Contents only on devices with a screen dimension ≥ 768px.
+By default, Hugo supports the Table of Contents generation by setting the `toc` parameter to `true` or `false` in the page metadata. `not-much` theme is rendering the Table of Contents in two different ways based on devices screens:
 
-If you are on medium/large device, you will find the ToC on the right side of the screen.
+- Screen dimension ≤ 768px: the Table of Contents is shown before the post content.
+- Screen dimension ≥ 768px: the Table of Contents is shown on the right side of the screen and follows the page scrolling.
 
 ### Nested Chapter
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,14 +3,6 @@
     <div class="row mt-5 pt-5">
       {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
     </div>
-    {{ if .Params.toc }}
-    <div class="toc small">
-      <p class="toc-title fw-semibold">
-        Table of Contents:
-      </p>
-      {{ .TableOfContents }}
-    </div>
-    {{ end }}
     <div class="post">
       <header class="mb-4">
         <h1 class="text-uppercase">{{ .Title }}</h1>
@@ -37,6 +29,14 @@
           </ol>
         </div>
       </header>
+      {{ if .Params.toc }}
+      <div class="toc small">
+        <p class="toc-title fw-semibold">
+          Table of Contents:
+        </p>
+        {{ .TableOfContents }}
+      </div>
+      {{ end }}
       <article>
         {{ .Content }}
       </article>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
       {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
     </div>
     {{ if .Params.toc }}
-    <div class="d-none d-lg-block position-fixed small toc">
+    <div class="toc small">
       <p class="toc-title fw-semibold">
         Table of Contents:
       </p>


### PR DESCRIPTION
This PR shows the table of contents on small-screen devices. On medium/large screen devices, the Table of Contents behaves in the same way, but on small screen devices, it is now shown before the post content.