### PR TITLE
Remove the Gist shortcode example

### DIFF
--- a/exampleSite/content/posts/hugo-shortcodes.md
+++ b/exampleSite/content/posts/hugo-shortcodes.md
@@ -43,11 +43,6 @@ func main() {
 
 {{< figure src="https://images.unsplash.com/photo-1560032779-0a8809186efd?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=80" title="Dave Herring" >}}
 
-
-## Github Gist
-
-{{< gist imgios f587d813ec6c851d700054f89230fb42 >}}
-
 ## Youtube video
 
 {{< youtube w7Ft2ymGmfc >}}


### PR DESCRIPTION
This PR removes the Gist shortcode example from the theme exampleSite post. The shortcode is deprecated in Hugo v0.143.0[^1][^2]

[^1]: https://github.com/gohugoio/hugo/releases/tag/v0.143.0
[^2]: https://github.com/gohugoio/hugo/issues/13211