### PR TITLE
Bump hugo to `0.149.1`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.140.2
+      HUGO_VERSION: 0.149.1
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
This PR changes the Hugo version in the workflow to the `0.149.1`, to support the new Hugo Template System.