### PR TITLE
Fix navbar margin on medium devices

### DIFF
--- a/layouts/_partials/menu.html
+++ b/layouts/_partials/menu.html
@@ -38,7 +38,7 @@ Renders a menu for the given menu ID.
         {{- $name = . }}
       {{- end }}
     {{- end }}
-    <li class="breadcrumb-item my-1 mx-md-0 ms-3 ms-md-0">
+    <li class="breadcrumb-item my-1 my-md-0 ms-3 ms-md-0">
       <a
         {{- range $k, $v := $attrs }}
           {{- with $v }}


### PR DESCRIPTION
This PR fixes the bottom margin of the navbar items on medium-sized devices. The root cause was a typo introduced in #57. 