### PR TITLE
layouts/baseof.html: fixing deprecated variables

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}" dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<html lang="{{ or site.Language.Locale site.Language.Lang }}" dir="{{ or site.Language.Direction `ltr` }}">
 <head>
   {{ partial "head.html" . }}
 </head>


### PR DESCRIPTION
Variables .Language.LanguageCode and .Language.LanguageDirection were deprecated in Hugo v0.158.0 (as per warning when using a newer version of Hugo) and might be unsupported in a future version. .Language.Locale and .Language.Direction are their respective new names.

This commit substitutes the new variables for the deprecated ones, thus suppressing the warning.