### PR TITLE
Moving call to footer to layouts/baseof.html

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -105,6 +105,17 @@ showThemeNotice = true # or false
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+## Footer
+
+By default, the footer is only rendered in blog posts. To make it appear:everywhere throughout your site, set this:
+
+<kbd>config.toml</kbd>
+
+```toml
+[params]
+showFooterEverywhere = true
+```
+
 ## Math rendering with KaTeX
 
 You can enable the math rendering by adding `math: true` in the page metadata.

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -36,5 +36,12 @@
     detectThemePreferences();
   </script>
   {{- end }}
+
+  {{ if .Site.Params.showFooterEverywhere}}
+    <footer>
+      {{ partial "footer.html" . }}
+    </footer>
+  {{ end }}
+
 </body>
 </html>

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -47,7 +47,9 @@
       {{ end }}
     </div>
   </div>
-  <footer>
-    {{ partial "footer.html" . }}
-  </footer>
+  {{ if not .Site.Params.showFooterEverywhere }}
+    <footer>
+      {{ partial "footer.html" . }}
+    </footer>
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
Moving the call to the footer partial from layouts/single.html to layouts/baseof.html so that it's printed in all pages throughout the site.

As far as I can tell, the expected behavior in Hugo-based sites is to have the footer (when present) to be visible everywhere. This commit makes it possible.