### PR TITLE
Add multilingual support

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -14,6 +14,7 @@ A reference can be found in [`exampleSite/config.toml`](https://github.com/imgio
 - [Posts Summary in the Posts list](#posts-summary-in-the-posts-list)
 - [Table of Contents](#table-of-contents)
 - [Giscus Comments](#giscus-comments)
+- [Site languages](#site-languages)
 
 ## Homepage
 
@@ -164,9 +165,16 @@ categoryName = "categoryName"
 categoryId = "categoryId"
 mapping = "pathname"
 theme = "preferred_color_scheme"
-language = "en"
 lazyLoading = true
+
+[languages]
+  [languages.en]
+    [languages.en.params.giscus]
+    language = "en"
 ```
+
+> [!IMPORTANT]
+> Pay attention to the Giscus language parameter. As you can see, it is configured in a different block related to the site language since it's the only language-dependent setting. E.g., `[languages.en.params.giscus]`
 
 Both `repositoryId` and `categoryId` can be fetched from Giscus website.
 
@@ -178,6 +186,44 @@ Once configured, you can enable comments by using the `comments` parameter in th
 ...
 comments: true
 ---
+```
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Site Languages
+
+This theme supports the Hugo Multilingual mechanism based on i18n. To configure your site language, you have to add the following parameters:
+
+```toml
+defaultContentLanguage = "en"
+
+[languages]
+  [languages.en]
+    languageName = "English"
+    locale = "en"
+    weight = 1
+    [languages.en.params.giscus]
+    language = "en"
+```
+
+The example is done using the English language, but you can customise it with any other language. Make sure the related language code translation file is stored in the `i18n/` folder.
+
+If you want to support more than one language, you can configure more under `[languages]`, e.g.:
+
+```toml
+[languages]
+  [languages.en]
+    languageName = "English"
+    locale = "en"
+    weight = 1
+    [languages.en.params.giscus]
+    language = "en"
+  [languages.it]
+    languageName = "Italiano"
+    locale = "it"
+    weight = 2
+    [languages.it.params.giscus]
+    language = "it"
 ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,9 +5,19 @@ themesDir = "../../"
 
 title = "not-much demo"
 theme = "not-much"
-languageCode = "en-us"
 baseURL = "https://example.org/"
 copyright = "Sample custom notice © {year}"
+
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = false
+
+[languages]
+  [languages.en]
+    languageName = "English"
+    locale = "en"
+    weight = 1
+    [languages.en.params.giscus]
+    language = "en"
 
 [markup]
   [markup.highlight]
@@ -15,7 +25,6 @@ copyright = "Sample custom notice © {year}"
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
-
 
 [params]
 theme = "auto"
@@ -31,7 +40,7 @@ categoryName = "categoryName"
 categoryId = "categoryId"
 mapping = "pathname"
 theme = "preferred_color_scheme"
-language = "en"
+# language = "en" is configured directly under languages.<languageCode>.params.giscus
 lazyLoading = true
 
 # Navigation

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -45,21 +45,18 @@ lazyLoading = true
   
   [[menu.main]]
     identifier = "posts"
-    name = "posts"
     title = "posts"
     url = "/posts"
     weight = 3
   
   [[menu.main]]
     identifier = "about"
-    name = "about"
     title = "About"
     url = "/about"
     weight = 2
   
   [[menu.main]]
     identifier = "tags"
-    name = "tags"
     title = "tags"
     url = "/tags"
     weight = 4

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,6 +18,12 @@ defaultContentLanguageInSubdir = false
     weight = 1
     [languages.en.params.giscus]
     language = "en"
+  [languages.it]
+    languageName = "Italiano"
+    locale = "it"
+    weight = 2
+    [languages.it.params.giscus]
+    language = "it"
 
 [markup]
   [markup.highlight]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -18,6 +18,9 @@ other = "previous"
 [next]
 other = "next"
 
+[back]
+other = "back"
+
 [updated]
 other = "Updated"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,35 @@
+[home]
+other = "Home"
+
+[post]
+one = "Post"
+other = "Posts"
+
+[about]
+other = "About"
+
+[tag]
+one = "Tag"
+other = "Tags"
+
+[previous]
+other = "previous"
+
+[next]
+other = "next"
+
+[updated]
+other = "Updated"
+
+[minute]
+one = "minute"
+other = "minutes"
+
+[tableOfContents]
+other = "Table of Contents"
+
+[draft]
+other = "DRAFT"
+
+[toggleNavigation]
+other = "Toggle navigation"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -33,3 +33,9 @@ other = "DRAFT"
 
 [toggleNavigation]
 other = "Toggle navigation"
+
+[pageNotFound]
+other = "For sure this is not what you are looking for."
+
+[GoBackToHome]
+other = "Return to the home page"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,14 +1,14 @@
 [home]
-other = "Home"
+other = "home"
 
 [posts]
-other = "Posts"
+other = "posts"
 
 [about]
-other = "About"
+other = "about"
 
 [tags]
-other = "Tags"
+other = "tags"
 
 [previous]
 other = "previous"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,8 +1,7 @@
 [home]
 other = "Home"
 
-[post]
-one = "Post"
+[posts]
 other = "Posts"
 
 [about]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -7,8 +7,7 @@ other = "Posts"
 [about]
 other = "About"
 
-[tag]
-one = "Tag"
+[tags]
 other = "Tags"
 
 [previous]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -21,9 +21,9 @@ other = "next"
 [updated]
 other = "Updated"
 
-[minute]
-one = "minute"
-other = "minutes"
+[readingTime]
+one = "{{ .Count }} minute"
+other = "{{ .Count }} minutes"
 
 [tableOfContents]
 other = "Table of Contents"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -42,3 +42,6 @@ other = "For sure this is not what you are looking for."
 
 [GoBackToHome]
 other = "Return to the home page"
+
+[contentLinked]
+other = "content linked to"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -1,0 +1,45 @@
+[home]
+other = "home"
+
+[posts]
+other = "posts"
+
+[about]
+other = "about"
+
+[tags]
+other = "tags"
+
+[previous]
+other = "precedente"
+
+[next]
+other = "prossimo"
+
+[back]
+other = "indietro"
+
+[updated]
+other = "Aggiornato"
+
+[readingTime]
+one = "{{ .Count }} minuto"
+other = "{{ .Count }} minuti"
+
+[tableOfContents]
+other = "Tabella dei Contenuti"
+
+[draft]
+other = "BOZZA"
+
+[toggleNavigation]
+other = "Abilita navigazione"
+
+[pageNotFound]
+other = "Di sicuro non è questo ciò che stavi cercando."
+
+[GoBackToHome]
+other = "Ritorna all'homepage"
+
+[contentLinked]
+other = "contenuti correlati a"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,10 +3,10 @@
     <h1 class="h5 mb-3 mt-5 pt-5">404</h1>
     <div class="row mb-3">
       <p>
-        For sure this is not what you are looking for.
+        {{ T "pageNotFound" }}
       </p>
       <a href="{{ .Site.Home.RelPermalink }}">
-        ← Return to the home page
+        ← {{ T "GoBackToHome" }}
       </a>
     </div>
   </div>

--- a/layouts/_partials/post-pagination.html
+++ b/layouts/_partials/post-pagination.html
@@ -1,16 +1,16 @@
 <div class="row">
     <div class="col-md">
         {{if .PrevInSection}}
-        <a href="{{.PrevInSection.Permalink}}">
-            <span>previous: </span>
+        <a href="{{.PrevInSection.RelPermalink}}">
+            <span>{{ T "previous" }}: </span>
             <span>{{.PrevInSection.Title}}</span>
         </a>
         {{end}}
     </div>
     <div class="col-md text-md-end">
         {{if .NextInSection}}
-        <a href="{{.NextInSection.Permalink}}">
-            <span>next: </span>
+        <a href="{{.NextInSection.RelPermalink}}">
+            <span>{{ T "next" }}: </span>
             <span>{{.NextInSection.Title}}</span>
         </a>
         {{end}}

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -25,12 +25,12 @@
       <ol class="breadcrumb">
         {{ if $paginator.HasPrev }}
         <li class="breadcrumb-item">
-          <a href="{{ $paginator.Prev.URL }}">← back</a>
+          <a href="{{ $paginator.Prev.URL }}">← {{T "back" }}</a>
         </li>
         {{ end }}
         {{ if $paginator.HasNext }}
         <li class="breadcrumb-item">
-          <a href="{{ $paginator.Next.URL }}">next →</a>
+          <a href="{{ $paginator.Next.URL }}">{{ T "next" }} →</a>
         </li>
         {{ end }}
       </ol>

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -12,7 +12,7 @@
           <ol class="breadcrumb">
             <li class="breadcrumb-item small">
               {{ if .Draft }}
-              <span class="draft-label">DRAFT</span> &#183;
+              <span class="draft-label">{{ T "draft" }}</span> &#183;
               {{ end }}
               <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
             </li>
@@ -20,11 +20,11 @@
             {{ if and (isset .Params "lastmod") (ne $lastModMachine $dateMachine) }}
             {{ $lastModHuman := .Lastmod | time.Format ":date_long" }}
             <li class="breadcrumb-item small">
-              Updated: <time datetime="{{ $lastModMachine }}">{{ $lastModHuman }}</time>
+              {{ T "updated" }}: <time datetime="{{ $lastModMachine }}">{{ $lastModHuman }}</time>
             </li>
             {{ end }}
             <li class="breadcrumb-item small">
-              {{ printf "%d minutes" .ReadingTime }}
+              {{ T "readingTime" (dict "Count" .ReadingTime) }}
             </li>
           </ol>
         </div>
@@ -32,7 +32,7 @@
       {{ if .Params.toc }}
       <div class="toc small">
         <p class="toc-title fw-semibold">
-          Table of Contents:
+          {{ T "tableOfContents" }}:
         </p>
         {{ .TableOfContents }}
       </div>

--- a/layouts/term.html
+++ b/layouts/term.html
@@ -3,7 +3,7 @@
       <div class="row mt-5 pt-5">
         {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
       </div>
-      <h1 class="h5 mb-3">content linked to <span class="text-lowercase underline">{{ .Title }}</span></h1>
+      <h1 class="h5 mb-3">{{ T "contentLinked" }} <span class="text-lowercase underline">{{ .Title }}</span></h1>
       {{ .Content }}
       {{ range .Pages }}
       <div class="row mb-3">


### PR DESCRIPTION
This PR adds the multilingual support to the theme leveraging on the Hugo built-in i18n translation mechanism.

https://gohugo.io/content-management/multilingual/

Closes #63 