### PR TITLE
feat: add a minimal language selector to the nav menu

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -226,4 +226,6 @@ If you want to support more than one language, you can configure more under `[la
     language = "it"
 ```
 
+Once more than one language is configured, the theme automatically shows a minimal language selector next to the navigation menu. It links to the translated version of the current page when one exists, or to that language's homepage otherwise, and needs no extra configuration.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -43,3 +43,6 @@ other = "Return to the home page"
 
 [contentLinked]
 other = "content linked to"
+
+[chooseLanguage]
+other = "Choose language"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -43,3 +43,6 @@ other = "Ritorna all'homepage"
 
 [contentLinked]
 other = "contenuti correlati a"
+
+[chooseLanguage]
+other = "Scegli la lingua"

--- a/layouts/_partials/menu.html
+++ b/layouts/_partials/menu.html
@@ -34,6 +34,36 @@ Renders a menu for the given menu ID.
   </nav>
 {{- end }}
 
+{{- partial "inline/menu/language-selector.html" $page }}
+
+{{- define "partials/inline/menu/language-selector.html" }}
+  {{- if hugo.IsMultilingual }}
+    {{- $page := . }}
+    {{- $translations := dict }}
+    {{- range $page.AllTranslations }}
+      {{- $translations = merge $translations (dict .Language.Lang .) }}
+    {{- end }}
+    <ul aria-label="{{ T "chooseLanguage" }}" class="language-selector list-inline small mb-0 mt-2">
+      {{- range site.Sites }}
+        {{- $langCode := .Language.Lang }}
+        {{- $target := index $translations $langCode }}
+        {{- if not $target }}
+          {{- $target = .Home }}
+        {{- end }}
+        {{- with $target }}
+        <li class="list-inline-item">
+          <a href="{{ .RelPermalink }}"
+            {{- if eq $langCode $page.Language.Lang }}
+            class="text-decoration-underline link-offset-3" aria-current="page"
+            {{- end }}
+          >{{ or .Language.LanguageName $langCode }}</a>
+        </li>
+        {{- end }}
+      {{- end }}
+    </ul>
+  {{- end }}
+{{- end }}
+
 {{- define "partials/inline/menu/walk.html" }}
   {{- $page := .page }}
   {{- range .menuEntries }}


### PR DESCRIPTION
## What & why

The theme has supported Hugo's multilingual mechanism since 0.22.0, but there was no way to switch between configured languages other than knowing the language's URL path directly (e.g. `www.example.com/it/`).

Closes #67

## What changed

- `layouts/_partials/menu.html` — added a `language-selector` inline partial, rendered wherever `menu.html` is already used (home, single, list, taxonomy, term), guarded by `hugo.IsMultilingual` so it's a no-op on single-language sites.
  - For each configured language (via `site.Sites`), it links to the current page's translation when one exists (via `Page.AllTranslations`), and falls back to that language's homepage when the current page has no translation.
  - The active language is marked with `text-decoration-underline link-offset-3` + `aria-current="page"`, matching the convention already used for the active item in the main nav (`walk.html`).
- `i18n/en.toml` / `i18n/it.toml` — added a `chooseLanguage` key used as the selector's `aria-label`.
- `configuration.md` — documented the new behavior under the existing "Site Languages" section.

## How it was verified

Built `exampleSite` locally with Hugo 0.158.0 (the version pinned in `.github/workflows/cd.yaml`) after temporarily adding a second language, and inspected the rendered HTML:

- On both `/` (English) and `/it/` (Italian) homepages, the selector lists both languages, links correctly, and marks the current one active.
- On a post that only exists in English (`/posts/example-post/`), the English entry links to itself (active) and the Italian entry correctly falls back to the Italian homepage, since no translation exists.
- Build is clean with no new warnings/errors introduced by this change.

## Checklist

- [x] Branch created off `main` (no `dev` branch currently exists on the remote)
- [x] `README.md`/`configuration.md` updated with details of the new feature
- [x] No JS added — pure Hugo template logic